### PR TITLE
Implemented Retries

### DIFF
--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -327,6 +327,7 @@ for db in $DBNAME; do
                     fi
                     index_size_after=`check_index_size $index`
                     info "  completed repack index $index size after: $index_size_after MB"
+                    db_maintenance_benefit=$((db_maintenance_benefit+index_size_before-index_size_after))
                     # check for invalid temporary indexes with the suffix "index_"
                     invalid_index=$(psql -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
                     if [ -n "$invalid_index" ]; then
@@ -365,12 +366,11 @@ for db in $DBNAME; do
                 sleep 2s
                 done
             fi
-            total_maintenance_benefit=$((total_maintenance_benefit+db_maintenance_benefit))
             info "Completed index maintenance for database: $db"
             info "Totally released for database $db - $db_maintenance_benefit MB"
         fi
     fi
+    total_maintenance_benefit=$((total_maintenance_benefit+db_maintenance_benefit))
 done
 info "Totally released during maintenance - $total_maintenance_benefit MB"
-
 exit

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -37,6 +37,9 @@ while getopts ":-:" optchar; do
         maintenance_stop=* )
             MAINTENANCE_STOP=${OPTARG#*=}
             ;;
+        failed_per_db_threshold=* )
+            FAILED_PER_DB_THRESHOLD=${OPTARG#*=}
+            ;;
     esac
 done
 
@@ -75,6 +78,10 @@ $(basename "$0") - Automatic reindexing of B-tree indexes
         estimate - index bloat estimation (default)
         pgstattuple - use pgstattuple extension to search bloat indexes (could cause I/O spikes) [ optional ]
 
+\e[1m--failed_per_db_threshold=\e[0m
+        If set, script will keep running for specific database, until more than this number of indexes fail to reindex.
+        After reaching threshold - script moves to next database (default: 1)
+
 -h, --help
         show this help, then exit
 
@@ -96,18 +103,36 @@ exit
 [ "$1" = "-h" ] || [ "$1" = "help" ] || [ "$1" = "-help" ] || [ "$1" = "--help" ] && help
 
 function info(){
-    msg="$1"
+    if [ -n "$1" ]; then
+        msg="$1"
+    else
+        read msg
+        msg="  $msg"
+    fi
     echo -e "$(date "+%F %T") INFO: $msg"
     logger -p user.notice -t "$(basename "$0")" "$msg"
 }
 function warnmsg(){
-    msg="$1"
+    if [ -n "$1" ]; then
+        msg="$1"
+    else
+        read msg
+        msg="  $msg"
+        if [[ $msg == "  " ]]; then
+            return 0
+        fi
+    fi
     echo -e "$(date "+%F %T") \e[33mWARN:\e[0m $msg"
     logger -p user.notice -t "$(basename "$0")" "$msg"
     return 1
 }
 function errmsg(){
-    msg="$1"
+    if [ -n "$1" ]; then
+        msg="$1"
+    else
+        read msg
+        msg="  $msg"
+    fi
     echo -e "$(date "+%F %T") \e[91mERROR:\e[0m $msg"
     logger -p user.error -t "$(basename "$0")" "$msg"
     exit 1
@@ -121,6 +146,7 @@ if [[ -z $INDEX_BLOAT ]]; then INDEX_BLOAT="30"; fi
 if [[ -z $BLOAT_SEARCH_METHOD ]]; then BLOAT_SEARCH_METHOD="estimate"; fi
 if [[ -z $INDEX_MINSIZE ]]; then INDEX_MINSIZE="1"; fi
 if [[ -z $INDEX_MAXSIZE ]]; then INDEX_MAXSIZE="1000000"; fi
+if [[ -z $FAILED_PER_DB_THRESHOLD ]]; then FAILED_PER_DB_THRESHOLD="1"; fi
 
 PG_VERSION=$(psql -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d $(echo ${DBNAME}|awk '{print $1}') -tAXc "select setting::integer/10000 from pg_settings where name = 'server_version_num'")
 
@@ -312,54 +338,81 @@ for db in $DBNAME; do
              info "  no bloat indexes were found"
              info "Completed index maintenance for database: $db"
         else
+            per_db_failed_indexes=0
             db_maintenance_benefit=0
             # if postgres <= 11 use pg_repack
             if [[ $PG_VERSION -le 11 ]]; then
                 create_extension_pg_repack
                 for index in $bloat_indexes; do
+                    if [[ $per_db_failed_indexes -ge $FAILED_PER_DB_THRESHOLD ]]; then
+                        warnmsg "Index maintenance for database: $db exceeded $FAILED_PER_DB_THRESHOLD failed indexes. Skipping."
+                        break
+                    fi
                     pg_isready
                     maintenance_window
                     index_size_before=`check_index_size $index`
                     info "  started repack index $index size: $index_size_before MB"
-                    if ! bash -c "PGOPTIONS=\"${PGOPTIONS}\" pg_repack -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d $db -i '$index' --elevel=ERROR";
-                    then
-                        errmsg "Index maintenance for database: $db - Failed"
-                    fi
-                    index_size_after=`check_index_size $index`
-                    info "  completed repack index $index size after: $index_size_after MB"
-                    db_maintenance_benefit=$((db_maintenance_benefit+index_size_before-index_size_after))
+                    for delay in 0 10 30 60
+                    do
+                        sleep $delay
+                        if bash -c "PGOPTIONS=\"${PGOPTIONS}\" pg_repack -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d $db -i '$index' --elevel=ERROR" 2>&1 | warnmsg; then
+                            break
+                        else
+                            if [[ $delay -eq 60 ]]; then
+                                warnmsg "  failed to repack index $index after all attempts. Skipping"
+                                per_db_failed_indexes=$((per_db_failed_indexes+1))
+                                continue 2
+                            fi
+                            warnmsg "  failed repack index $index."
+                        fi
+                    done
                     # check for invalid temporary indexes with the suffix "index_"
                     invalid_index=$(psql -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
                     if [ -n "$invalid_index" ]; then
                         warnmsg "A temporary index apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves. If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
                         warnmsg "invalid indexes: $invalid_index"
-
-                        errmsg "Index maintenance for database: $db - Failed"
+                        warnmsg "Index maintenance for database: $db - Failed. Skipping."
+                        continue 2
                     fi
+                    index_size_after=`check_index_size $index`
+                    info "  completed repack index $index size after: $index_size_after MB"
+                    db_maintenance_benefit=$((db_maintenance_benefit+index_size_before-index_size_after))
                 sleep 2s
                 done
             # if postgres >= 12 use reindex concurrently
             elif [[ $PG_VERSION -ge 12 ]]; then
                 for index in $bloat_indexes; do
+                    if [[ $per_db_failed_indexes -ge $FAILED_PER_DB_THRESHOLD ]]; then
+                        warnmsg "Index maintenance for database: $db exceeded $FAILED_PER_DB_THRESHOLD failed indexes. Skipping."
+                        break
+                    fi
                     pg_isready
                     maintenance_window
                     index_size_before=`check_index_size $index`
                     info "  started reindex index $index size: $index_size_before MB"
-                    if ! bash -c "PGOPTIONS=\"${PGOPTIONS}\" psql -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d $db -tAXc 'REINDEX INDEX CONCURRENTLY $index' 1> /dev/null";
-                    then
-                        # If the index marked INVALID is suffixed ccnew, then it corresponds to the transient index created during the concurrent operation, and the recommended recovery method is to drop it using DROP INDEX 
-                        invalid_index=$(psql -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d "$db" -tAXc "SELECT quote_ident(schemaname)||'.'||quote_ident(indexrelname) as invalid_index FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND quote_ident(schemaname)||'.'||quote_ident(indexrelname) = '${index}_ccnew'")
-                        if [ -n "$invalid_index" ]; then
-                            warnmsg "  drop invalid index $invalid_index"
-                            if ! bash -c "PGOPTIONS=\"${PGOPTIONS}\" psql -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d $db -tAXc 'DROP INDEX CONCURRENTLY $invalid_index' 1> /dev/null";
-                            then
-                                warnmsg "  failed to drop invalid index $invalid_index"
-                                warnmsg "The index marked INVALID with the suffixed ccnew corresponds to the transient index created during the concurrent operation, and the recommended recovery method is to drop it using DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
+                    for delay in 0 10 30 60
+                    do
+                        sleep $delay
+                        if bash -c "PGOPTIONS=\"${PGOPTIONS}\" psql -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d $db -tAXc 'REINDEX INDEX CONCURRENTLY $index' 1> /dev/null" 2>&1 | warnmsg; then
+                            break
+                        else
+                            invalid_index=$(psql -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d "$db" -tAXc "SELECT quote_ident(schemaname)||'.'||quote_ident(indexrelname) as invalid_index FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND quote_ident(schemaname)||'.'||quote_ident(indexrelname) = '${index}_ccnew'")
+                            if [ -n "$invalid_index" ]; then
+                                warnmsg "  drop invalid index $invalid_index"
+                                if ! bash -c "PGOPTIONS=\"${PGOPTIONS}\" psql -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d $db -tAXc 'DROP INDEX CONCURRENTLY $invalid_index' 1> /dev/null";
+                                then
+                                    warnmsg "  failed to drop invalid index $invalid_index"
+                                    warnmsg "The index marked INVALID with the suffixed ccnew corresponds to the transient index created during the concurrent operation, and the recommended recovery method is to drop it using DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
+                                fi
                             fi
+                            if [[ $delay -eq 60 ]]; then
+                                warnmsg "  failed to reindex index $index after all attempts. Skipping"
+                                per_db_failed_indexes=$((per_db_failed_indexes+1))
+                                continue 2
+                            fi
+                            warnmsg "  failed reindex index $index. Retrying"
                         fi
-                        warnmsg "   failed to reindex index $index"
-                        errmsg "Index maintenance for database: $db - Failed"
-                    fi
+                    done
                     index_size_after=`check_index_size $index`
                     info "  completed reindex index $index size after: $index_size_after MB"
                     db_maintenance_benefit=$((db_maintenance_benefit+index_size_before-index_size_after))

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -329,6 +329,7 @@ maintenance_window
 # REINDEX
 total_maintenance_benefit=0
 for db in $DBNAME; do
+    db_maintenance_benefit=0
     if pg_isready; then
     create_extension_pgstattuple
     info "Started index maintenance for database: $db"
@@ -339,7 +340,6 @@ for db in $DBNAME; do
              info "Completed index maintenance for database: $db"
         else
             per_db_failed_indexes=0
-            db_maintenance_benefit=0
             # if postgres <= 11 use pg_repack
             if [[ $PG_VERSION -le 11 ]]; then
                 create_extension_pg_repack
@@ -355,7 +355,7 @@ for db in $DBNAME; do
                     for delay in 0 10 30 60
                     do
                         sleep $delay
-                        if bash -c "PGOPTIONS=\"${PGOPTIONS}\" pg_repack -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d $db -i '$index' --elevel=ERROR" 2>&1 | warnmsg; then
+                        if bash -c "PGOPTIONS=\"${PGOPTIONS}\" pg_repack -h ${PGHOST} -p ${PGPORT} -U ${DBUSER} -d $db -i '$index' --elevel=WARNING" 2>&1 | warnmsg; then
                             break
                         else
                             if [[ $delay -eq 60 ]]; then


### PR DESCRIPTION
1) Now every index will retry rebuild after the fail:
  after first fail - with 10 seconds delay 
  after second fail - with 30 seconds delay
  after third fail - with 60 seconds delay.
If all attempts failed - index is considered failed to reindex.
Script will not fail, and will continue with next index.
If more than `failed_per_db_threshold` index failed for 1 db - db is considered failed to process, and script continues with next db.
2) Reworked logging functions to be able to process stdin along with usual strings.
Reworked warnmsg to return zero code, in case receiving empty stdin.
Replaced errmsg calls in processing part with warn+continue.
These changer were required to redirect strerr to functions and keep output in the same format
3) Had to lower the error level for pg_repack, since it considered the "timeout errors" as WARNINGS
```postgres@postgres14host:~$ PGOPTIONS="-c statement_timeout=0 -c lock_timeout=1s" pg_repack  -p 5435 -i public.newtest4  -d testdb --elevel=ERROR
postgres@postgres14host:~$ PGOPTIONS="-c statement_timeout=0 -c lock_timeout=1s" pg_repack  -p 5435 -i public.newtest4  -d testdb
INFO: repacking index "public.newtest4"
WARNING: Error creating index "public"."index_82480": ERROR:  canceling statement due to lock timeout
WARNING: Skipping index swapping for "public.events", since no new indexes built
INFO: Skipping drop of index_82480
WARNING: repack failed for "public.newtest4"
```
4) Fixed incorrect counters of totally released space. It didn't work for pg_repack, now it fixed.
5) New parameter 
```
--failed_per_db_threshold=
        If set, script will keep running for specific database, until more than this number of indexes fail to reindex.
        After reaching threshold - script moves to next database (default: 1)
```

Examples of outputs.
Failed repack:
```
postgres@postgres14host:~$ ./pg_auto_reindexer --pgport=5435 --bloat_search_method=pgstattuple
2022-12-02 20:32:58 INFO: Started index maintenance for database: postgres
2022-12-02 20:32:58 INFO:   no bloat indexes were found
2022-12-02 20:32:58 INFO: Completed index maintenance for database: postgres
2022-12-02 20:32:58 INFO: Started index maintenance for database: testdb
2022-12-02 20:32:58 INFO:   started repack index public.newtest2 size: 10 MB
2022-12-02 20:32:59 WARN:   WARNING: Error creating index "public"."index_82482": ERROR:  canceling statement due to lock timeout
2022-12-02 20:32:59 WARN:   failed repack index public.newtest2.
2022-12-02 20:33:10 WARN:   WARNING: Error creating index "public"."index_82482": ERROR:  canceling statement due to lock timeout
2022-12-02 20:33:10 WARN:   failed repack index public.newtest2.
2022-12-02 20:33:41 WARN:   WARNING: Error creating index "public"."index_82482": ERROR:  canceling statement due to lock timeout
2022-12-02 20:33:41 WARN:   failed repack index public.newtest2.
2022-12-02 20:34:42 WARN:   WARNING: Error creating index "public"."index_82482": ERROR:  canceling statement due to lock timeout
2022-12-02 20:34:42 WARN:   failed to repack index public.newtest2 after all attempts. Skipping
2022-12-02 20:34:42 WARN: Index maintenance for database: testdb exceeded 1 failed indexes. Skipping.
2022-12-02 20:34:42 INFO: Completed index maintenance for database: testdb
2022-12-02 20:34:42 INFO: Totally released for database testdb - 0 MB
2022-12-02 20:34:42 INFO: Started index maintenance for database: newtest
2022-12-02 20:34:42 INFO:   no bloat indexes were found
2022-12-02 20:34:42 INFO: Completed index maintenance for database: newtest
2022-12-02 20:34:42 INFO: Totally released during maintenance - 0 MB
```
Failed reindex (default):
```
postgres@postgres14host:~$ ./pg_auto_reindexer --pgport=5435 --bloat_search_method=pgstattuple
2022-12-02 19:58:29 INFO: Started index maintenance for database: postgres
2022-12-02 19:58:29 INFO:   no bloat indexes were found
2022-12-02 19:58:29 INFO: Completed index maintenance for database: postgres
2022-12-02 19:58:29 INFO: Started index maintenance for database: testdb
2022-12-02 19:58:30 INFO:   started reindex index public.test4 size: 103 MB
2022-12-02 19:58:31 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:58:31 WARN:   failed reindex index public.test4. Retrying
2022-12-02 19:58:42 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:58:42 WARN:   failed reindex index public.test4. Retrying
2022-12-02 19:59:13 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:59:13 WARN:   failed reindex index public.test4. Retrying
2022-12-02 20:00:14 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 20:00:14 WARN:   failed to reindex index public.test4 after all attempts. Skipping
2022-12-02 20:00:14 WARN: Index maintenance for database: testdb exceeded 1 failed indexes. Skipping.
2022-12-02 20:00:14 INFO: Completed index maintenance for database: testdb
2022-12-02 20:00:14 INFO: Totally released for database testdb - 0 MB
2022-12-02 20:00:14 INFO: Started index maintenance for database: newtest
2022-12-02 20:00:14 INFO:   no bloat indexes were found
2022-12-02 20:00:14 INFO: Completed index maintenance for database: newtest
2022-12-02 20:00:14 INFO: Totally released during maintenance - 0 MB
```

Failed reindex (custom threshold):
```
postgres@postgres14host:~$ ./pg_auto_reindexer --pgport=5435 --bloat_search_method=pgstattuple --failed_per_db_threshold=2
2022-12-02 19:53:39 INFO: Started index maintenance for database: postgres
2022-12-02 19:53:39 INFO:   no bloat indexes were found
2022-12-02 19:53:39 INFO: Completed index maintenance for database: postgres
2022-12-02 19:53:39 INFO: Started index maintenance for database: testdb
2022-12-02 19:53:39 INFO:   started reindex index public.test4 size: 103 MB
2022-12-02 19:53:40 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:53:40 WARN:   failed reindex index public.test4. Retrying
2022-12-02 19:53:52 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:53:52 WARN:   failed reindex index public.test4. Retrying
2022-12-02 19:54:23 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:54:23 WARN:   failed reindex index public.test4. Retrying
2022-12-02 19:55:24 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:55:24 WARN:   failed to reindex index public.test4 after all attempts. Skipping
2022-12-02 19:55:24 INFO:   started reindex index public.test3 size: 103 MB
2022-12-02 19:55:25 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:55:25 WARN:   failed reindex index public.test3. Retrying
2022-12-02 19:55:36 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:55:36 WARN:   failed reindex index public.test3. Retrying
2022-12-02 19:56:07 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:56:07 WARN:   failed reindex index public.test3. Retrying
2022-12-02 19:57:08 WARN:   ERROR:  canceling statement due to lock timeout
2022-12-02 19:57:08 WARN:   failed to reindex index public.test3 after all attempts. Skipping
2022-12-02 19:57:08 WARN: Index maintenance for database: testdb exceeded 2 failed indexes. Skipping.
2022-12-02 19:57:08 INFO: Completed index maintenance for database: testdb
2022-12-02 19:57:08 INFO: Totally released for database testdb - 0 MB
2022-12-02 19:57:08 INFO: Started index maintenance for database: newtest
2022-12-02 19:57:08 INFO:   no bloat indexes were found
2022-12-02 19:57:08 INFO: Completed index maintenance for database: newtest
2022-12-02 19:57:08 INFO: Totally released during maintenance - 0 MB
```
