### PR TITLE
Fixes #6 for pg_repack invalid leftovers 

### DIFF
--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -362,8 +362,7 @@ for db in $DBNAME; do
               # check for invalid temporary indexes with the suffix "index_"
               invalid_index=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
               if [ -n "$invalid_index" ]; then
-                warnmsg "  A temporary index apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves."
-                warnmsg "  If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
+                warnmsg "  A temporary index apparently created by pg_repack has been left behind."
                 warnmsg "  failed to repack index \"$index\". Skipping"
                 failed_reindex_count=$((failed_reindex_count+1))
                 continue 2
@@ -430,11 +429,12 @@ for db in $DBNAME; do
   if [[ -n "$bloat_indexes" ]] && [[ $failed_reindex_count -lt $FAILED_REINDEX_LIMIT ]]; then
     info "Completed index maintenance for database: $db (released: $db_maintenance_benefit MB)"
   fi
-  invalid_index=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
-  if [ -n "$invalid_index" ]; then
+  invalid_index_drop_commands=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$db" -tAXc "SELECT string_agg('DROP INDEX CONCURRENTLY '||quote_ident(schemaname)||'.'||quote_ident(indexrelname), '; ')||';' FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
+  if [ -n "$invalid_index_drop_commands" ]; then
     info "A temporary index(es) apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves."
-    info "If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
-    info "Invalid index(es): $invalid_index" 
+    info "If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use next commands:"
+    info "$invalid_index_drop_commands" 
+    info "and run pg_auto_reindexer again."
   fi
 done
 info "Total amount released during maintenance: $total_maintenance_benefit MB"

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -325,6 +325,7 @@ maintenance_window
 # REINDEX
 total_maintenance_benefit=0
 for db in $DBNAME; do
+  invalid_indexes_count=0
   db_maintenance_benefit=0
   if pg_isready; then
     create_extension_pgstattuple
@@ -359,6 +360,15 @@ for db in $DBNAME; do
               info "  completed repack index $index (size after: $index_size_after MB)"
               break
             else
+              # check for invalid temporary indexes with the suffix "index_"
+              invalid_index=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
+              if [ -n "$invalid_index" ]; then
+                invalid_indexes_count=$((invalid_indexes_count+1))
+                warnmsg "  A temporary index apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves."
+                warnmsg "  If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
+                warnmsg "  failed to repack index \"$index\". Skipping"
+                continue 2
+              fi
               retry_n=$((retry_n+1))
               # Skipping repack after all attempts
               if [[ $delay -eq 60 ]]; then
@@ -368,13 +378,6 @@ for db in $DBNAME; do
               fi
             fi
           done
-          # check for invalid temporary indexes with the suffix "index_"
-          invalid_index=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
-          if [ -n "$invalid_index" ]; then
-            warnmsg "A temporary index apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves. If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
-            warnmsg "invalid indexes: $invalid_index"
-            continue 2
-          fi
           db_maintenance_benefit=$((db_maintenance_benefit+index_size_before-index_size_after))
         sleep 2s
         done
@@ -427,6 +430,12 @@ for db in $DBNAME; do
   total_maintenance_benefit=$((total_maintenance_benefit+db_maintenance_benefit))
   if [[ -n "$bloat_indexes" ]] && [[ $failed_reindex_count -lt $FAILED_REINDEX_LIMIT ]]; then
     info "Completed index maintenance for database: $db (released: $db_maintenance_benefit MB)"
+  fi
+  if [[ $invalid_indexes_count -gt 0 ]]; then
+    invalid_index=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
+    info "A temporary index(es) apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves."
+    info "If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
+    info "Invalid index(es): $invalid_index" 
   fi
 done
 info "Total amount released during maintenance: $total_maintenance_benefit MB"

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -365,6 +365,7 @@ for db in $DBNAME; do
                 warnmsg "  A temporary index apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves."
                 warnmsg "  If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
                 warnmsg "  failed to repack index \"$index\". Skipping"
+                failed_reindex_count=$((failed_reindex_count+1))
                 continue 2
               fi
               retry_n=$((retry_n+1))

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -325,7 +325,6 @@ maintenance_window
 # REINDEX
 total_maintenance_benefit=0
 for db in $DBNAME; do
-  invalid_indexes_count=0
   db_maintenance_benefit=0
   if pg_isready; then
     create_extension_pgstattuple
@@ -363,7 +362,6 @@ for db in $DBNAME; do
               # check for invalid temporary indexes with the suffix "index_"
               invalid_index=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
               if [ -n "$invalid_index" ]; then
-                invalid_indexes_count=$((invalid_indexes_count+1))
                 warnmsg "  A temporary index apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves."
                 warnmsg "  If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
                 warnmsg "  failed to repack index \"$index\". Skipping"
@@ -431,8 +429,8 @@ for db in $DBNAME; do
   if [[ -n "$bloat_indexes" ]] && [[ $failed_reindex_count -lt $FAILED_REINDEX_LIMIT ]]; then
     info "Completed index maintenance for database: $db (released: $db_maintenance_benefit MB)"
   fi
-  if [[ $invalid_indexes_count -gt 0 ]]; then
-    invalid_index=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
+  invalid_index=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$db" -tAXc "SELECT string_agg(quote_ident(schemaname)||'.'||quote_ident(indexrelname), ', ') FROM pg_stat_user_indexes sui JOIN pg_index i USING (indexrelid) WHERE NOT indisvalid AND indexrelname like 'index_%'")
+  if [ -n "$invalid_index" ]; then
     info "A temporary index(es) apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves."
     info "If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use DROP INDEX CONCURRENTLY and try the pg_auto_reindexer again."
     info "Invalid index(es): $invalid_index" 


### PR DESCRIPTION
Fixes vitabaks/pg_auto_reindexer#6

Reworked the case of invalid indexes after repack
Now script won't stop
In the end of db maintenance will print a list of invalids with commands to drop them.

Final output look:
```
postgres@postgres14host:~$ ./pg_auto_reindexer.sh --pgport=5435 --bloat_search_method=pgstattuple --failed_reindex_limit=4
2022-12-10 18:08:55 INFO: Started index maintenance for database: postgres
2022-12-10 18:08:55 INFO:   no bloat indexes were found
2022-12-10 18:08:55 INFO: Completed index maintenance for database: postgres
2022-12-10 18:08:55 INFO: Started index maintenance for database: testdb
2022-12-10 18:08:55 INFO:   no bloat indexes were found
2022-12-10 18:08:55 INFO: Completed index maintenance for database: testdb
2022-12-10 18:08:55 INFO: Started index maintenance for database: newtest
2022-12-10 18:08:55 INFO:   repack index public.newtest2 (size: 10 MB)
2022-12-10 18:08:56 WARN:   WARNING: Error creating index "public"."index_123216": ERROR:  canceling statement due to lock timeout
2022-12-10 18:08:56 WARN:   A temporary index apparently created by pg_repack has been left behind.
2022-12-10 18:08:56 WARN:   failed to repack index "public.newtest2". Skipping
2022-12-10 18:08:56 INFO:   repack index public.newtest4 (size: 10 MB)
2022-12-10 18:08:57 WARN:   WARNING: Error creating index "public"."index_123214": ERROR:  canceling statement due to lock timeout
2022-12-10 18:08:57 WARN:   A temporary index apparently created by pg_repack has been left behind.
2022-12-10 18:08:57 WARN:   failed to repack index "public.newtest4". Skipping
2022-12-10 18:08:57 INFO:   repack index public.newtest3 (size: 10 MB)
2022-12-10 18:08:58 WARN:   WARNING: Error creating index "public"."index_123215": ERROR:  canceling statement due to lock timeout
2022-12-10 18:08:59 WARN:   A temporary index apparently created by pg_repack has been left behind.
2022-12-10 18:08:59 WARN:   failed to repack index "public.newtest3". Skipping
2022-12-10 18:08:59 INFO:   repack index public.events_pkey (size: 33 MB)
2022-12-10 18:09:00 WARN:   WARNING: Error creating index "public"."index_123211": ERROR:  canceling statement due to lock timeout
2022-12-10 18:09:00 WARN:   A temporary index apparently created by pg_repack has been left behind.
2022-12-10 18:09:00 WARN:   failed to repack index "public.events_pkey". Skipping
2022-12-10 18:09:00 WARN: Index maintenance for database: newtest exceeded 4 failed index repacking. Skipping.
2022-12-10 18:09:00 INFO: A temporary index(es) apparently created by pg_repack has been left behind, and we do not want to risk dropping this index ourselves.
2022-12-10 18:09:00 INFO: If the index was in fact created by an old pg_repack job which didn't get cleaned up, you should just use next commands:
2022-12-10 18:09:00 INFO: DROP INDEX CONCURRENTLY public.index_123211; DROP INDEX CONCURRENTLY public.index_123214; DROP INDEX CONCURRENTLY public.index_123215; DROP INDEX CONCURRENTLY public.index_123216;
2022-12-10 18:09:00 INFO: and run pg_auto_reindexer again.
2022-12-10 18:09:00 INFO: Started index maintenance for database: support
2022-12-10 18:09:00 INFO:   no bloat indexes were found
2022-12-10 18:09:00 INFO: Completed index maintenance for database: support
```