### PR TITLE
Fix the shebang line for systems which do not have bash in /bin

### DIFF
--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Vitaliy Kukharik (vitabaks@gmail.com)
 # Title: /usr/bin/pg_auto_reindexer - Automatic reindexing of B-tree indexes
 


### PR DESCRIPTION
Thank you for the useful program.

This PR fixes it for NixOS, which does not have `/bin/bash` (it does have a `/usr/bin` containing just `env`).