### PR TITLE
Fix `FATAL:  database "Timing" does not exist` when there is a `.psqlrc` containing `\timing`.

### DIFF
--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -139,7 +139,7 @@ function errmsg(){
 if [[ -z $PGHOST ]]; then PGHOST="/var/run/postgresql"; fi
 if [[ -z $PGPORT ]]; then PGPORT="5432"; fi
 if [[ -z $DBUSER ]]; then DBUSER="postgres"; fi
-if [[ -z $DBNAME ]]; then if ! DBNAME=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d postgres -tAc "select datname from pg_database where not datistemplate"); then errmsg "Unable to connect to database postgres on ${PGHOST}:${PGPORT} "; fi; fi
+if [[ -z $DBNAME ]]; then if ! DBNAME=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d postgres -tAXc "select datname from pg_database where not datistemplate"); then errmsg "Unable to connect to database postgres on ${PGHOST}:${PGPORT} "; fi; fi
 if [[ -z $INDEX_BLOAT ]]; then INDEX_BLOAT="30"; fi
 if [[ -z $BLOAT_SEARCH_METHOD ]]; then BLOAT_SEARCH_METHOD="estimate"; fi
 if [[ -z $INDEX_MINSIZE ]]; then INDEX_MINSIZE="1"; fi


### PR DESCRIPTION
This fixes `FATAL:  database "Timing" does not exist` from `pg_auto_reindexer` when there is a `.psqlrc` containing `\timing`.

I confirmed that `pg_auto_reindexer` worked with this change.

```
$ ./pg_auto_reindexer
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "Timing" does not exist
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "Timing" does not exist
2022-12-26 12:04:28 ERROR: PostgreSQL server /var/run/postgresql:5432 no response
```

```
/var/lib/postgresql/14$ cat .psqlrc
-- Based on https://github.com/davidfetter/settings/blob/master/.psqlrc

\timing
\set HISTCONTROL ignoreboth
\set HISTSIZE -1
\set ON_ERROR_STOP
\set PROMPT1 '%n@%M:%:PORT:/%/(%:SERVER_VERSION_NAME:)(%p) %# '
\set PROMPT2 '> '
\pset linestyle unicode
\pset border 2
\pset unicode_header_linestyle double
\pset unicode_border_linestyle single
\pset unicode_column_linestyle single
\setenv LESS '-MFXSx4R'
```

```
$ psql
Timing is on.
Line style is unicode.
Border style is 2.
Unicode header line style is "double".
Unicode border line style is "single".
Unicode column line style is "single".
psql (14.6)
Type "help" for help.
```