### PR TITLE
Fix Shell linter warnings

### DIFF
--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -146,14 +146,14 @@ if [[ -z $INDEX_MINSIZE ]]; then INDEX_MINSIZE="1"; fi
 if [[ -z $INDEX_MAXSIZE ]]; then INDEX_MAXSIZE="1000000"; fi
 if [[ -z $FAILED_REINDEX_LIMIT ]]; then FAILED_REINDEX_LIMIT="1"; fi
 
-PG_VERSION=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$(echo "${DBNAME}" | awk '{print $1}')" -tAXc "select setting::integer/10000 from pg_settings where name = 'server_version_num'")
+PG_VERSION=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$(echo "${DBNAME}" | awk 'NR==1')" -tAXc "select setting::integer/10000 from pg_settings where name = 'server_version_num'")
 
 function pg_isready(){
-  if ! psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$(echo "${DBNAME}" | awk '{print $1}')" -tAXc "select 1" 1> /dev/null; then
+  if ! psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$(echo "${DBNAME}" | awk 'NR==1')" -tAXc "select 1" 1> /dev/null; then
     errmsg "PostgreSQL server ${PGHOST}:${PGPORT} no response"
   else
   # in recovery mode?
-  state=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$(echo "${DBNAME}" | awk '{print $1}')" -tAXc 'SELECT pg_is_in_recovery()') 2>/dev/null
+  state=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$(echo "${DBNAME}" | awk 'NR==1')" -tAXc 'SELECT pg_is_in_recovery()') 2>/dev/null
     if [ "$state" = "t" ]; then
       warnmsg "This server is in recovery mode. Index maintenance will not be performed on that server."
       exit

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -146,14 +146,14 @@ if [[ -z $INDEX_MINSIZE ]]; then INDEX_MINSIZE="1"; fi
 if [[ -z $INDEX_MAXSIZE ]]; then INDEX_MAXSIZE="1000000"; fi
 if [[ -z $FAILED_REINDEX_LIMIT ]]; then FAILED_REINDEX_LIMIT="1"; fi
 
-PG_VERSION=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d $(echo ${DBNAME}|awk '{print $1}') -tAXc "select setting::integer/10000 from pg_settings where name = 'server_version_num'")
+PG_VERSION=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$(echo "${DBNAME}" | awk '{print $1}')" -tAXc "select setting::integer/10000 from pg_settings where name = 'server_version_num'")
 
 function pg_isready(){
-  if ! psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d $(echo ${DBNAME}|awk '{print $1}') -tAXc "select 1" 1> /dev/null; then
+  if ! psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$(echo "${DBNAME}" | awk '{print $1}')" -tAXc "select 1" 1> /dev/null; then
     errmsg "PostgreSQL server ${PGHOST}:${PGPORT} no response"
   else
   # in recovery mode?
-  state=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d $(echo ${DBNAME}|awk '{print $1}') -tAXc 'SELECT pg_is_in_recovery()') 2>/dev/null
+  state=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d "$(echo "${DBNAME}" | awk '{print $1}')" -tAXc 'SELECT pg_is_in_recovery()') 2>/dev/null
     if [ "$state" = "t" ]; then
       warnmsg "This server is in recovery mode. Index maintenance will not be performed on that server."
       exit


### PR DESCRIPTION
Fixed:

```
In bin/pg_auto_reindexer line 149:
PG_VERSION=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d $(echo ${DBNAME}|awk '{print $1}') -tAXc "select setting::integer/10000 from pg_settings where name = 'server_version_num'")
                                                                  ^-- SC2046 (warning): Quote this to prevent word splitting.
                                                                         ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
PG_VERSION=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d $(echo "${DBNAME}"|awk '{print $1}') -tAXc "select setting::integer/10000 from pg_settings where name = 'server_version_num'")
In bin/pg_auto_reindexer line 152:
  if ! psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d $(echo ${DBNAME}|awk '{print $1}') -tAXc "select 1" 1> /dev/null; then
                                                            ^-- SC2046 (warning): Quote this to prevent word splitting.
                                                                   ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
  if ! psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d $(echo "${DBNAME}"|awk '{print $1}') -tAXc "select 1" 1> /dev/null; then
In bin/pg_auto_reindexer line 156:
  state=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d $(echo ${DBNAME}|awk '{print $1}') -tAXc 'SELECT pg_is_in_recovery()') 2>/dev/null
                                                               ^-- SC2046 (warning): Quote this to prevent word splitting.
                                                                      ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
  state=$(psql -h "${PGHOST}" -p "${PGPORT}" -U "${DBUSER}" -d $(echo "${DBNAME}"|awk '{print $1}') -tAXc 'SELECT pg_is_in_recovery()') 2>/dev/null
For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```