### PR TITLE
Fix maintenance window handling for overnight time ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Output example:
 ```
 2025-04-28 01:00:57 INFO: Started index maintenance for database: casdb
 2025-04-28 01:00:58 INFO:  no bloat indexes were found
+2025-04-28 01:00:58 INFO: Completed index maintenance for database: casdb (released: 0 MB)
 2025-04-28 01:01:00 INFO: Started index maintenance for database: crsdb
 2025-04-28 01:01:08 INFO:  reindex index carousel.crs_queue_low_head_idx (current size: 180 MB)
 2025-04-28 01:01:33 INFO:  completed reindex carousel.crs_queue_low_head_idx (new size: 26 MB, reduced: 85%)

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -276,7 +276,7 @@ function pg_isready(){
     errmsg "PostgreSQL server ${PGHOST}:${PGPORT} no response"
   else
   # in recovery mode?
-  state=$(${_PSQL} -d "$(echo "${DBNAME}" | awk 'NR==1')" -tAXc 'SELECT pg_is_in_recovery()') 2>/dev/null
+  state=$(${_PSQL} -d "$(echo "${DBNAME}" | awk 'NR==1')" -tAXc 'select pg_is_in_recovery()') 2>/dev/null
     if [[ "${state}" = "t" ]]; then
       warnmsg "This server is in recovery mode. Index maintenance will not be performed on that server."
       exit
@@ -398,7 +398,7 @@ process_reindex() {
 # Check current time
 maintenance_window
 
-# Perform reindexing for each database
+# Perform reindexing
 total_maintenance_benefit=0
 db_count=0
 
@@ -409,12 +409,12 @@ for db in ${DBNAME}; do
   if pg_isready; then
     info "Started index maintenance for database: ${db}"
 
-    if [[ "${BLOAT_SEARCH_METHOD}" = "pgstattuple" ]]; then
-      create_extension_pgstattuple
-    fi
-
     if [[ "${PG_VERSION}" -le 11 ]]; then
       create_extension_pg_repack
+    fi
+
+    if [[ "${BLOAT_SEARCH_METHOD}" = "pgstattuple" ]]; then
+      create_extension_pgstattuple
     fi
 
     bloat_indexes=$(${_PSQL} -d "${db}" -tAXc "${INDEX_BLOAT_SQL}")

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -298,8 +298,24 @@ function check_index_size(){
 
 function maintenance_window(){
   if [[ -n "${MAINTENANCE_START}" ]] && [[ -n "${MAINTENANCE_STOP}" ]]; then
-    currentTime=$(date "+%H%M")
-    if [[ "${currentTime}" -lt "${MAINTENANCE_START}" ]] || [[ "${currentTime}" -gt "${MAINTENANCE_STOP}" ]]; then
+    currentTime=$((10#$(date "+%H%M")))
+    start=$((10#${MAINTENANCE_START}))
+    stop=$((10#${MAINTENANCE_STOP}))
+    out_of_window=false
+
+    if [[ "${start}" -le "${stop}" ]]; then
+      # Window does NOT cross midnight
+      if [[ "${currentTime}" -lt "${start}" || "${currentTime}" -gt "${stop}" ]]; then
+        out_of_window=true
+      fi
+    else
+      # Window CROSSES midnight
+      if [[ "${currentTime}" -gt "${stop}" && "${currentTime}" -lt "${start}" ]]; then
+        out_of_window=true
+      fi
+    fi
+
+    if [[ "${out_of_window}" == true ]]; then
       warnmsg "Current time: $(date "+%R %Z"). This is outside of the maintenance window: $(date --date="${MAINTENANCE_START}" "+%R")-$(date --date="${MAINTENANCE_STOP}" "+%R"). Exit."
       exit
     fi


### PR DESCRIPTION
Fixed `maintenance_window()` logic to properly handle cases where the maintenance window crosses midnight (e.g., 22:00–03:00).