### PR TITLE
Fix handling of special characters or spaces

### DIFF
--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -440,7 +440,7 @@ maintenance_window
 total_maintenance_benefit=0
 db_count=0
 
-for db in ${DBNAME}; do
+while IFS= read -r db; do
   db_count=$((db_count + 1))
   db_maintenance_benefit=0
 
@@ -495,7 +495,7 @@ for db in ${DBNAME}; do
 
     total_maintenance_benefit=$((total_maintenance_benefit + db_maintenance_benefit))
   fi
-done
+done < <(echo "${DBNAME}")
 
 if (( db_count > 1 )); then
   info "Total amount released during maintenance: ${total_maintenance_benefit} MB"

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -460,7 +460,7 @@ for db in ${DBNAME}; do
       index_count=$(echo "$bloat_indexes"|wc -l)
       info "${index_count} indexes have been found for reindexing"
       i=1
-      for index in ${bloat_indexes}; do
+      while IFS= read -r index; do
         pg_isready
         maintenance_window
 
@@ -481,7 +481,7 @@ for db in ${DBNAME}; do
 
         db_maintenance_benefit=$((db_maintenance_benefit + index_size_before - index_size_after))
         ((i++))
-      done
+      done < <(echo "${bloat_indexes}")
     else
       info " no bloat indexes were found"
     fi


### PR DESCRIPTION
Replaced `for` loop with a `while read -r` loop to properly process index and database names containing spaces or special characters.

This ensures safe and accurate reindexing by preserving the full index identifier without word splitting.

Fixed:

```
2025-06-17 11:06:06 INFO:  completed reindex public.dojo_findin_date_8e9143_idx (new size: 4 MB, reduced: 96%)
ERROR:  invalid name syntax
LINE 1: select pg_relation_size('public."endpoint-finding')/1024/102...
                                ^
2025-06-17 11:06:06 INFO:  reindex index public."endpoint-finding (current size:  MB)
2025-06-17 11:06:07 WARN: ERROR:  unterminated quoted identifier at or near ""endpoint-finding"
LINE 1: REINDEX INDEX CONCURRENTLY public."endpoint-finding
                                         ^
```