### PR TITLE
Disable transaction_timeout option

### DIFF
--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -115,6 +115,11 @@ PG_VERSION=$(
 # Disable statement_timeout and set lock_timeout
 PGOPTIONS="-c statement_timeout=0 -c lock_timeout=1s"
 
+# transaction_timeout exists since PG 17, so add it only for PG>=17.
+if [[ "${PG_VERSION}" -ge 17 ]]; then
+  PGOPTIONS+=" -c transaction_timeout=0"
+fi
+
 # Configure the number of parallel workers for maintenance operations.
 # Note: The actual number of workers may be less than requested due to system limits (max_parallel_workers).
 # Setting this value to 0 (default) disables the use of parallel workers.


### PR DESCRIPTION
Set the `transaction_timeout=0` option in `PGOPTIONS` for PostgreSQL 17 or higher.

Fixed:

```
2025-12-29 00:02:49 UTC [1130183-2] [local] postgres@***_prod STATEMENT:  REINDEX INDEX CONCURRENTLY public.index_events_on_customer_id
2025-12-29 00:02:50 UTC [1126843-20] [local] postgres@***_prod FATAL:  terminating connection due to transaction timeout
```