### PR TITLE
Add disk free space checks before reindexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Reindexing options:
   -l, --failed-reindex-limit=N      Max reindex failures before skipping DB (default: 0)
   -j, --jobs=N                      Number of parallel workers for reindex (default: 1)
   -o, --sorting-order=(asc|desc)    Defines the sorting order of indexes by size (default: asc)
+  -r, --disk-free-reserve=MB        Disk free space reserve in MB (default: 5120)
 
 Other options:
   -v, --version                     Show version information and exit

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -437,7 +437,7 @@ function ensure_free_space() {
   }
 
   if (( avail_mb < required_mb )); then
-    warnmsg " Insufficient free space for ${index} (index tablespace): avail ${avail_mb} MB at ${index_dir}, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
+    warnmsg " Insufficient free space for index tablespace: avail ${avail_mb} MB at ${index_dir}, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
     return 1
   fi
 
@@ -449,7 +449,7 @@ function ensure_free_space() {
   }
 
   if (( avail_mb < required_mb )); then
-    warnmsg " Insufficient free space on data directory filesystem: avail ${avail_mb} MB at ${data_dir}, need reserve ${DISK_FREE_RESERVE_MB} MB (WAL/temp safety)."
+    warnmsg " Insufficient free space on data directory: avail ${avail_mb} MB at ${data_dir}, need reserve ${DISK_FREE_RESERVE_MB} MB (WAL/temp safety)."
     return 1
   fi
 

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -421,7 +421,7 @@ function ensure_free_space() {
     }
 
     if (( avail_mb < required_mb )); then
-      warnmsg " Insufficient free space for ${index}: avail ${avail_mb} MB at ${data_dir}, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
+      warnmsg " Insufficient free space: avail ${avail_mb} MB at ${data_dir}, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
       return 1
     fi
 

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -2,7 +2,7 @@
 # Author: Vitaliy Kukharik (vitabaks@gmail.com)
 # Title: pg_auto_reindexer - Automatic reindexing of B-tree indexes
 
-version=1.6
+version=1.7
 
 # ========================
 # === Help information ===
@@ -323,6 +323,48 @@ function check_index_size(){
   ${_PSQL} -d "${db}" -tAXc "select pg_relation_size('$1')/1024/1024"
 }
 
+# --- Disk free space safety checks (PGDATA filesystem) ---
+# Free space check for REINDEX:
+# During REINDEX (especially REINDEX CONCURRENTLY) Postgres build a second copy of the index,
+# so worst-case peak usage requires roughly one extra index size on top of existing data.
+# We also keep a fixed reserve (1GB by default), e.q., for WAL growth on the same filesystem.
+: "${PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB:=1024}" # fixed headroom on top of index size (you can redefine it in env)
+
+function get_pgdata_dir() {
+  ${_PSQL} -d "${db}" -tAXc "show data_directory"
+}
+
+function get_pgdata_avail_mb() {
+  local pgdata_dir
+  pgdata_dir="$(get_pgdata_dir 2>/dev/null | awk 'NF{print; exit}')"
+  [[ -n "${pgdata_dir}" ]] || return 1
+  command -v df >/dev/null 2>&1 || return 1
+  # POSIX output, MB blocks
+  df -Pm "${pgdata_dir}" 2>/dev/null | awk 'NR==2{print $4}'
+}
+
+function ensure_pgdata_free_space() {
+  local index_mb="$1"
+  local index_name="$2"
+  local avail_mb
+  local required_mb
+
+  avail_mb="$(get_pgdata_avail_mb)" || {
+    warnmsg " Unable to verify free space on PGDATA filesystem."
+    return 1
+  }
+
+  # integer math for factor: required = current index size + reserve
+  required_mb=$(( index_mb + PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB ))
+
+  if (( avail_mb < required_mb )); then
+    warnmsg " Insufficient free space on PGDATA filesystem (avail: ${avail_mb} MB, required: ${required_mb} MB)."
+    return 1
+  fi
+
+  return 0
+}
+
 function maintenance_window(){
   if [[ -n "${MAINTENANCE_START}" ]] && [[ -n "${MAINTENANCE_STOP}" ]]; then
     currentTime=$((10#$(date "+%H%M")))
@@ -417,8 +459,11 @@ process_reindex() {
   local retry_n=0
   local delays=(0 10 30 60)
 
+  ccold_index=false
+  success=false
+
   # Drop INVALID ccnew/ccold indexes (if any) before starting REINDEX
-  drop_invalid_index "${index}" 
+  drop_invalid_index "${index}"
 
   for delay in "${delays[@]}"; do
     sleep "${delay}"
@@ -466,6 +511,7 @@ db_count=0
 while IFS= read -r db; do
   db_count=$((db_count + 1))
   db_maintenance_benefit=0
+  failed_reindex_count=0
 
   if pg_isready; then
     info "Started index maintenance for database: ${db}"
@@ -488,18 +534,25 @@ while IFS= read -r db; do
         maintenance_window
 
         index_size_before=$(check_index_size "${index}")
+        index_size_after="${index_size_before}" # default for failed/skip paths
+
         info "[$i/${index_count}] reindex index ${index} (current size: ${index_size_before} MB)"
 
-        process_reindex "${index}"
+        if ensure_pgdata_free_space "${index_size_before}" "${index}"; then
+          process_reindex "${index}"
 
-        if [[ "${success}" == true ]]; then
-          index_size_after=$(check_index_size "${index}")
-          if (( index_size_before > 0 )); then
-            saved_percent=$(( (index_size_before - index_size_after) * 100 / index_size_before ))
-          else
-            saved_percent=0
+          if [[ "${success}" == true ]]; then
+            index_size_after=$(check_index_size "${index}")
+            if (( index_size_before > 0 )); then
+              saved_percent=$(( (index_size_before - index_size_after) * 100 / index_size_before ))
+            else
+              saved_percent=0
+            fi
+            info "[$i/${index_count}] completed reindex ${index} (new size: ${index_size_after} MB, reduced: ${saved_percent}%)"
           fi
-          info "[$i/${index_count}] completed reindex ${index} (new size: ${index_size_after} MB, reduced: ${saved_percent}%)"
+        else
+          warnmsg " Stopping index maintenance for database: ${db} due to insufficient disk space (failed on ${index}, size: ${index_size_before} MB)."
+          break
         fi
 
         db_maintenance_benefit=$((db_maintenance_benefit + index_size_before - index_size_after))

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -337,7 +337,8 @@ function check_index_size(){
 # We also keep a fixed reserve (5GB by default), e.g., for WAL/temp files growth on the same filesystem.
 
 function get_pgdata_dir() {
-  ${_PSQL} -d "${db}" -tAXc "show data_directory"
+  ${_PSQL} -d "${db}" -tAXc "
+    select current_setting('data_directory')"
 }
 
 function get_index_dir() {
@@ -367,30 +368,88 @@ function get_path_avail_mb() {
   echo "${avail}"
 }
 
+function get_path_fs_id() {
+  local path="$1"
+  local fs
+
+  [[ -n "${path}" ]] || return 1
+
+  # Filesystem id (device) for this path
+  fs="$(df -P "${path}" 2>/dev/null | awk 'NR==2{print $1}')"
+  [[ -n "${fs}" ]] || return 1
+
+  echo "${fs}"
+}
+
 function ensure_free_space() {
   local index="$1"
   local index_mb="$2"
   local index_dir
   local data_dir
+  local index_fs
+  local data_fs
   local avail_mb
   local required_mb
 
-  dir="$(get_index_dir "${index}" 2>/dev/null | awk 'NF{print; exit}')"
-  [[ -n "${dir}" ]] || {
-    warnmsg " Unable to determine tablespace directory for ${index}."
+  index_dir="$(get_index_dir "${index}" 2>/dev/null | awk 'NF{print; exit}')"
+  [[ -n "${index_dir}" ]] || {
+    warnmsg " Unable to determine tablespace directory."
     return 1
   }
 
-  avail_mb="$(get_path_avail_mb "${dir}")" || {
-    warnmsg " Unable to verify free space on filesystem for ${index} (path: ${dir})."
+  data_dir="$(get_pgdata_dir 2>/dev/null | awk 'NF{print; exit}')"
+  [[ -n "${data_dir}" ]] || {
+    warnmsg " Unable to determine data directory."
     return 1
   }
 
-  # integer math for factor: required = current index size + reserve
+  index_fs="$(get_path_fs_id "${index_dir}")" || {
+    warnmsg " Unable to identify filesystem for ${index} (path: ${index_dir})."
+    return 1
+  }
+  data_fs="$(get_path_fs_id "${data_dir}")" || {
+    warnmsg " Unable to identify filesystem for data directory (path: ${data_dir})."
+    return 1
+  }
+
+  # If index and PGDATA are on the same filesystem, check only once (data_dir is enough).
+  if [[ "${index_fs}" == "${data_fs}" ]]; then
+    required_mb=$(( index_mb + DISK_FREE_RESERVE_MB ))
+    avail_mb="$(get_path_avail_mb "${data_dir}")" || {
+      warnmsg " Unable to verify free space on filesystem for ${index} (path: ${data_dir})."
+      return 1
+    }
+
+    if (( avail_mb < required_mb )); then
+      warnmsg " Insufficient free space for ${index}: avail ${avail_mb} MB at ${data_dir}, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
+      return 1
+    fi
+
+    return 0
+  fi
+
+  # Different filesystems: check BOTH.
+  # 1) Index tablespace FS needs space for new index copy + reserve.
   required_mb=$(( index_mb + DISK_FREE_RESERVE_MB ))
+  avail_mb="$(get_path_avail_mb "${index_dir}")" || {
+    warnmsg " Unable to verify free space on index filesystem for ${index} (path: ${index_dir})."
+    return 1
+  }
 
   if (( avail_mb < required_mb )); then
-    warnmsg " Insufficient free space for ${index}: avail ${avail_mb} MB at ${dir}, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
+    warnmsg " Insufficient free space for ${index} (index tablespace): avail ${avail_mb} MB at ${index_dir}, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
+    return 1
+  fi
+
+  # 2) PGDATA FS needs at least reserve for WAL/temp safety.
+  required_mb=$(( DISK_FREE_RESERVE_MB ))
+  avail_mb="$(get_path_avail_mb "${data_dir}")" || {
+    warnmsg " Unable to verify free space on data directory filesystem (path: ${data_dir})."
+    return 1
+  }
+
+  if (( avail_mb < required_mb )); then
+    warnmsg " Insufficient free space on data directory filesystem: avail ${avail_mb} MB at ${data_dir}, need reserve ${DISK_FREE_RESERVE_MB} MB (WAL/temp safety)."
     return 1
   fi
 

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -344,7 +344,6 @@ function get_pgdata_avail_mb() {
 
 function ensure_pgdata_free_space() {
   local index_mb="$1"
-  local index_name="$2"
   local avail_mb
   local required_mb
 
@@ -537,7 +536,7 @@ while IFS= read -r db; do
 
         info "[$i/${index_count}] reindex index ${index} (current size: ${index_size_before} MB)"
 
-        if ensure_pgdata_free_space "${index_size_before}" "${index}"; then
+        if ensure_pgdata_free_space "${index_size_before}"; then
           process_reindex "${index}"
 
           if [[ "${success}" == true ]]; then

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -2,7 +2,7 @@
 # Author: Vitaliy Kukharik (vitabaks@gmail.com)
 # Title: pg_auto_reindexer - Automatic reindexing of B-tree indexes
 
-version=1.8
+version=1.7
 
 # ========================
 # === Help information ===

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -550,8 +550,6 @@ while IFS= read -r db; do
             info "[$i/${index_count}] completed reindex ${index} (new size: ${index_size_after} MB, reduced: ${saved_percent}%)"
           fi
         else
-          warnmsg " Not enough free space on PGDATA (failed on ${index}, size: ${index_size_before} MB)."
-
           if [[ "${SORTING_ORDER}" == "asc" ]]; then
             warnmsg " Stopping index maintenance for database: ${db}."
             break
@@ -560,6 +558,7 @@ while IFS= read -r db; do
             ((i++))
             continue
           fi
+          info "[$i/${index_count}] completed reindex ${index} (new size: ${index_size_after} MB, reduced: ${saved_percent}%)"
         fi
 
         db_maintenance_benefit=$((db_maintenance_benefit + index_size_before - index_size_after))

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -30,6 +30,7 @@ Reindexing options:
   -l, --failed-reindex-limit=N      Max reindex failures before skipping DB (default: 0)
   -j, --jobs=N                      Number of parallel workers for reindex (default: 1)
   -o, --sorting-order=(asc|desc)    Defines the sorting order of indexes by size (default: asc)
+  -r, --disk-free-reserve=MB        Disk free space reserve in MB (default: 5120)
 
 Other options:
   -v, --version                     Show version information and exit
@@ -70,6 +71,7 @@ while [[ $# -gt 0 ]]; do
     -l|--failed-reindex-limit)  FAILED_REINDEX_LIMIT="$2"; shift 2;;
     -j|--jobs)                  PARALLEL_JOBS="$2"; shift 2;;
     -o|--sorting-order)         SORTING_ORDER="$2"; shift 2;;
+    -r|--disk-free-reserve)     DISK_FREE_RESERVE_MB="$2"; shift 2;;
     -v|--version)               echo "pg_auto_reindexer v${version}"; exit;;
     -?|--help)                  help;;
     *)
@@ -91,9 +93,15 @@ if [[ -z "${INDEX_MINSIZE}" ]]; then INDEX_MINSIZE="1"; fi
 if [[ -z "${INDEX_MAXSIZE}" ]]; then INDEX_MAXSIZE="1000000"; fi
 if [[ -z "${FAILED_REINDEX_LIMIT}" ]]; then FAILED_REINDEX_LIMIT="0"; fi
 if [[ -z "${SORTING_ORDER}" ]]; then SORTING_ORDER="asc"; fi
+if [[ -z "${DISK_FREE_RESERVE_MB}" ]]; then DISK_FREE_RESERVE_MB="5120"; fi
 
 if [[ "${SORTING_ORDER}" != "asc" && "${SORTING_ORDER}" != "desc" ]]; then
   echo "Invalid sorting order: ${SORTING_ORDER}. Allowed values: asc, desc."
+  exit 1
+fi
+
+if ! [[ "${DISK_FREE_RESERVE_MB}" =~ ^[0-9]+$ ]]; then
+  echo "Invalid --disk-free-reserve option (${DISK_FREE_RESERVE_MB}). An integer is expected."
   exit 1
 fi
 
@@ -327,7 +335,6 @@ function check_index_size(){
 # During REINDEX CONCURRENTLY Postgres build a second copy of the index,
 # so worst-case peak usage requires roughly one extra index size on top of existing data.
 # We also keep a fixed reserve (5GB by default), e.q., for WAL/temp files growth on the same filesystem.
-: "${PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB:=5120}" # fixed headroom on top of index size (you can redefine it in env)
 
 function get_pgdata_dir() {
   ${_PSQL} -d "${db}" -tAXc "show data_directory"
@@ -353,10 +360,10 @@ function ensure_pgdata_free_space() {
   }
 
   # integer math for factor: required = current index size + reserve
-  required_mb=$(( index_mb + PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB ))
+  required_mb=$(( index_mb + DISK_FREE_RESERVE_MB ))
 
   if (( avail_mb < required_mb )); then
-    warnmsg " Insufficient free space on PGDATA filesystem: avail ${avail_mb} MB, need ${required_mb} MB (index size ${index_mb} MB + reserve ${PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB} MB)."
+    warnmsg " Insufficient free space on PGDATA filesystem: avail ${avail_mb} MB, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
     return 1
   fi
 

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -550,8 +550,16 @@ while IFS= read -r db; do
             info "[$i/${index_count}] completed reindex ${index} (new size: ${index_size_after} MB, reduced: ${saved_percent}%)"
           fi
         else
-          warnmsg " Stopping index maintenance for database: ${db} due to insufficient disk space (failed on ${index}, size: ${index_size_before} MB)."
-          break
+          warnmsg " Not enough free space on PGDATA (failed on ${index}, size: ${index_size_before} MB)."
+
+          if [[ "${SORTING_ORDER}" == "asc" ]]; then
+            warnmsg " Stopping index maintenance for database: ${db}."
+            break
+          else
+            warnmsg " Skipping ${index} and continue with smaller indexes (sorting: ${SORTING_ORDER})."
+            ((i++))
+            continue
+          fi
         fi
 
         db_maintenance_benefit=$((db_maintenance_benefit + index_size_before - index_size_after))

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -643,10 +643,10 @@ while IFS= read -r db; do
           fi
         else
           if [[ "${SORTING_ORDER}" == "asc" ]]; then
-            warnmsg " Skip index maintenance for database: ${db}."
+            warnmsg " Skip index maintenance for database: ${db}"
             break
           else
-            warnmsg " Skip ${index} and continue with smaller indexes (sorting: ${SORTING_ORDER})."
+            warnmsg " Skip ${index} and continue with smaller indexes (sorting: ${SORTING_ORDER})"
             ((i++))
             continue
           fi

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -643,10 +643,10 @@ while IFS= read -r db; do
           fi
         else
           if [[ "${SORTING_ORDER}" == "asc" ]]; then
-            warnmsg " Stopping index maintenance for database: ${db}."
+            warnmsg " Skip index maintenance for database: ${db}."
             break
           else
-            warnmsg " Skipping ${index} and continue with smaller indexes (sorting: ${SORTING_ORDER})."
+            warnmsg " Skip ${index} and continue with smaller indexes (sorting: ${SORTING_ORDER})."
             ((i++))
             continue
           fi

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -326,8 +326,8 @@ function check_index_size(){
 # --- Disk free space safety checks (PGDATA filesystem) ---
 # During REINDEX CONCURRENTLY Postgres build a second copy of the index,
 # so worst-case peak usage requires roughly one extra index size on top of existing data.
-# We also keep a fixed reserve (1GB by default), e.q., for WAL growth on the same filesystem.
-: "${PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB:=1024}" # fixed headroom on top of index size (you can redefine it in env)
+# We also keep a fixed reserve (5GB by default), e.q., for WAL growth on the same filesystem.
+: "${PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB:=5120}" # fixed headroom on top of index size (you can redefine it in env)
 
 function get_pgdata_dir() {
   ${_PSQL} -d "${db}" -tAXc "show data_directory"

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -334,7 +334,7 @@ function check_index_size(){
 # --- Disk free space safety checks (PGDATA filesystem) ---
 # During REINDEX CONCURRENTLY Postgres build a second copy of the index,
 # so worst-case peak usage requires roughly one extra index size on top of existing data.
-# We also keep a fixed reserve (5GB by default), e.q., for WAL/temp files growth on the same filesystem.
+# We also keep a fixed reserve (5GB by default), e.g., for WAL/temp files growth on the same filesystem.
 
 function get_pgdata_dir() {
   ${_PSQL} -d "${db}" -tAXc "show data_directory"
@@ -342,11 +342,19 @@ function get_pgdata_dir() {
 
 function get_pgdata_avail_mb() {
   local pgdata_dir
+  local avail
+
   pgdata_dir="$(get_pgdata_dir 2>/dev/null | awk 'NF{print; exit}')"
   [[ -n "${pgdata_dir}" ]] || return 1
 
   # POSIX output, MB blocks
-  df -Pm "${pgdata_dir}" 2>/dev/null | awk 'NR==2{print $4}'
+  avail="$(df -Pm "${pgdata_dir}" 2>/dev/null | awk 'NR==2{print $4}')"
+  [[ "${avail}" =~ ^[0-9]+$ ]] || {
+    warnmsg " Unable to verify free space on PGDATA filesystem."
+    return 1
+  }
+
+  echo "${avail}"
 }
 
 function ensure_pgdata_free_space() {
@@ -354,10 +362,7 @@ function ensure_pgdata_free_space() {
   local avail_mb
   local required_mb
 
-  avail_mb="$(get_pgdata_avail_mb)" || {
-    warnmsg " Unable to verify free space on PGDATA filesystem."
-    return 1
-  }
+  avail_mb="$(get_pgdata_avail_mb)" || return 1
 
   # integer math for factor: required = current index size + reserve
   required_mb=$(( index_mb + DISK_FREE_RESERVE_MB ))

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -337,7 +337,7 @@ function get_pgdata_avail_mb() {
   local pgdata_dir
   pgdata_dir="$(get_pgdata_dir 2>/dev/null | awk 'NF{print; exit}')"
   [[ -n "${pgdata_dir}" ]] || return 1
-  command -v df >/dev/null 2>&1 || return 1
+
   # POSIX output, MB blocks
   df -Pm "${pgdata_dir}" 2>/dev/null | awk 'NR==2{print $4}'
 }
@@ -357,7 +357,7 @@ function ensure_pgdata_free_space() {
   required_mb=$(( index_mb + PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB ))
 
   if (( avail_mb < required_mb )); then
-    warnmsg " Insufficient free space on PGDATA filesystem (avail: ${avail_mb} MB, required: ${required_mb} MB)."
+    warnmsg " Insufficient free space on PGDATA filesystem: avail ${avail_mb} MB, need ${required_mb} MB (index size ${index_mb} MB + reserve ${PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB} MB)."
     return 1
   fi
 

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -2,7 +2,7 @@
 # Author: Vitaliy Kukharik (vitabaks@gmail.com)
 # Title: pg_auto_reindexer - Automatic reindexing of B-tree indexes
 
-version=1.7
+version=1.8
 
 # ========================
 # === Help information ===
@@ -331,44 +331,66 @@ function check_index_size(){
   ${_PSQL} -d "${db}" -tAXc "select pg_relation_size('$1')/1024/1024"
 }
 
-# --- Disk free space safety checks (PGDATA filesystem) ---
-# During REINDEX CONCURRENTLY Postgres build a second copy of the index,
-# so worst-case peak usage requires roughly one extra index size on top of existing data.
+# --- Disk free space safety checks (index tablespace filesystem) ---
+# During REINDEX CONCURRENTLY Postgres builds a second copy of the index in the index's tablespace.
+# So worst-case peak usage requires roughly one extra index size on that filesystem.
 # We also keep a fixed reserve (5GB by default), e.g., for WAL/temp files growth on the same filesystem.
 
 function get_pgdata_dir() {
   ${_PSQL} -d "${db}" -tAXc "show data_directory"
 }
 
-function get_pgdata_avail_mb() {
-  local pgdata_dir
+function get_index_dir() {
+  local index="$1"
+
+  # pg_tablespace_location() returns empty for pg_default; fallback to data directory
+  ${_PSQL} -d "${db}" -tAXc "
+    select coalesce(
+      nullif(pg_tablespace_location(c.reltablespace), ''),
+      current_setting('data_directory')
+    )
+    from pg_class c
+    where c.oid = '${index}'::regclass;
+  "
+}
+
+function get_path_avail_mb() {
+  local path="$1"
   local avail
 
-  pgdata_dir="$(get_pgdata_dir 2>/dev/null | awk 'NF{print; exit}')"
-  [[ -n "${pgdata_dir}" ]] || return 1
+  [[ -n "${path}" ]] || return 1
 
   # POSIX output, MB blocks
-  avail="$(df -Pm "${pgdata_dir}" 2>/dev/null | awk 'NR==2{print $4}')"
-  [[ "${avail}" =~ ^[0-9]+$ ]] || {
-    warnmsg " Unable to verify free space on PGDATA filesystem."
-    return 1
-  }
+  avail="$(df -Pm "${path}" 2>/dev/null | awk 'NR==2{print $4}')"
+  [[ "${avail}" =~ ^[0-9]+$ ]] || return 1
 
   echo "${avail}"
 }
 
-function ensure_pgdata_free_space() {
-  local index_mb="$1"
+function ensure_free_space() {
+  local index="$1"
+  local index_mb="$2"
+  local index_dir
+  local data_dir
   local avail_mb
   local required_mb
 
-  avail_mb="$(get_pgdata_avail_mb)" || return 1
+  dir="$(get_index_dir "${index}" 2>/dev/null | awk 'NF{print; exit}')"
+  [[ -n "${dir}" ]] || {
+    warnmsg " Unable to determine tablespace directory for ${index}."
+    return 1
+  }
+
+  avail_mb="$(get_path_avail_mb "${dir}")" || {
+    warnmsg " Unable to verify free space on filesystem for ${index} (path: ${dir})."
+    return 1
+  }
 
   # integer math for factor: required = current index size + reserve
   required_mb=$(( index_mb + DISK_FREE_RESERVE_MB ))
 
   if (( avail_mb < required_mb )); then
-    warnmsg " Insufficient free space on PGDATA filesystem: avail ${avail_mb} MB, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
+    warnmsg " Insufficient free space for ${index}: avail ${avail_mb} MB at ${dir}, need ${required_mb} MB (index size ${index_mb} MB + reserve ${DISK_FREE_RESERVE_MB} MB)."
     return 1
   fi
 
@@ -548,7 +570,7 @@ while IFS= read -r db; do
 
         info "[$i/${index_count}] reindex index ${index} (current size: ${index_size_before} MB)"
 
-        if ensure_pgdata_free_space "${index_size_before}"; then
+        if ensure_free_space "${index}" "${index_size_before}"; then
           process_reindex "${index}"
 
           if [[ "${success}" == true ]]; then
@@ -569,7 +591,6 @@ while IFS= read -r db; do
             ((i++))
             continue
           fi
-          info "[$i/${index_count}] completed reindex ${index} (new size: ${index_size_after} MB, reduced: ${saved_percent}%)"
         fi
 
         db_maintenance_benefit=$((db_maintenance_benefit + index_size_before - index_size_after))

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -324,8 +324,7 @@ function check_index_size(){
 }
 
 # --- Disk free space safety checks (PGDATA filesystem) ---
-# Free space check for REINDEX:
-# During REINDEX (especially REINDEX CONCURRENTLY) Postgres build a second copy of the index,
+# During REINDEX CONCURRENTLY Postgres build a second copy of the index,
 # so worst-case peak usage requires roughly one extra index size on top of existing data.
 # We also keep a fixed reserve (1GB by default), e.q., for WAL growth on the same filesystem.
 : "${PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB:=1024}" # fixed headroom on top of index size (you can redefine it in env)

--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -326,7 +326,7 @@ function check_index_size(){
 # --- Disk free space safety checks (PGDATA filesystem) ---
 # During REINDEX CONCURRENTLY Postgres build a second copy of the index,
 # so worst-case peak usage requires roughly one extra index size on top of existing data.
-# We also keep a fixed reserve (5GB by default), e.q., for WAL growth on the same filesystem.
+# We also keep a fixed reserve (5GB by default), e.q., for WAL/temp files growth on the same filesystem.
 : "${PG_AUTO_REINDEXER_DISK_FREE_RESERVE_MB:=5120}" # fixed headroom on top of index size (you can redefine it in env)
 
 function get_pgdata_dir() {


### PR DESCRIPTION
This pull request adds a disk free space safety check to the `pg_auto_reindexer` tool, ensuring that reindex operations do not proceed if there is insufficient disk space available. The changes introduce a new command-line option to specify a disk free space reserve, implement logic to check available space before reindexing indexes.

**Disk free space safety checks:**

* Added a new option `-r, --disk-free-reserve`, allowing users to set a minimum disk space reserve (default: 5120 MB).
* Implemented functions (`get_pgdata_dir`, `get_index_dir`, `get_path_avail_mb`, `get_path_fs_id`, `ensure_free_space`) to determine the index and data directory locations, check their filesystems, and verify sufficient free space before reindexing. The logic accounts for both cases when the index and data directory are on the same or different filesystems.
* Integrated the disk space check into the main reindexing loop, so indexes are only processed if there is enough free space. If not, the script either stops or skips indexes depending on the sorting order.
