### PR TITLE
Set PGOPTIONS when dropping invalid index

### DIFF
--- a/pg_auto_reindexer
+++ b/pg_auto_reindexer
@@ -504,7 +504,7 @@ drop_invalid_index() {
   if [[ -n "${invalid_indexes}" ]]; then
     while IFS= read -r invalid_index; do
       info " Invalid index detected: ${invalid_index}. Dropping."
-      if ! output=$(${_PSQL} -d "${db}" -tAXc "DROP INDEX CONCURRENTLY ${invalid_index}" 2>&1); then
+      if ! output=$(PGOPTIONS="${PGOPTIONS}" ${_PSQL} -d "${db}" -tAXc "DROP INDEX CONCURRENTLY ${invalid_index}" 2>&1); then
         warnmsg " Failed to drop invalid index ${invalid_index}: ${output}"
       fi
       if [[ "${status}" == false ]] && [[ "$(echo "$invalid_indexes" | wc -w)" -eq 1 ]]; then


### PR DESCRIPTION
When dropping invalid indexes in drop_invalid_index(), ensure the PGOPTIONS environment is passed to the psql invocation. The psql call was changed to prefix with PGOPTIONS="${PGOPTIONS}" so any session-level options are preserved for the DROP INDEX CONCURRENTLY command.

It is necessary first of all to specify `lock_timeout` to eliminate the lock queue.